### PR TITLE
Run tests in publish workflow, decouple test and publish workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,9 +14,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  Test:
-    uses: ./.github/workflows/ci.yml
-
   Publish:
     name: Publish package for ${{ github.ref_name }}
 
@@ -32,6 +29,15 @@ jobs:
         with:
           python_version: ${{ env.RELEASE_PYTHON_VERSION }}
           poetry_version: ${{ env.RELEASE_POETRY_VERSION }}
+
+      - name: 🔥 Test
+        run: poetry run poe test
+
+      - name: 🚒 Create test summary
+        uses: test-summary/action@v1
+        if: success() || failure()
+        with:
+          paths: tests/pytest.xml
 
       - name: 📦 Build package
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-  workflow_call:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The release workflow would invoke the test workflow to run tests, but
the actual package publishing was not dependent on the tests passing.