### PR TITLE
Rename pytest coverage and results output XML files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,14 +44,14 @@ jobs:
         uses: test-summary/action@v1
         if: success() || failure()
         with:
-          paths: tests/pytest.xml
+          paths: ./.pytest_results.xml
 
       - name: 📊 Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         if: ${{ env.ENABLE_COVERAGE == 'true' }}
         with:
           fail_ci_if_error: true
-          files: ./.coverage.xml
+          files: ./.pytest_coverage.xml
 
 concurrency:
   group: workflow-ci-${{ github.ref }}-1

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 *.egg-info/
 *.pyc
+.coverage
+.pytest_cache/
+.pytest_coverage.xml
+.pytest_results.xml
 .tox/
 .venv/
-.coverage
-.coverage.xml
 dist/
-tests/pytest.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ warn_unused_ignores = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--junitxml=tests/pytest.xml"
+addopts = "--junitxml=.pytest_results.xml"
 
 [tool.tox]
 legacy_tox_ini = """

--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -44,14 +44,14 @@ jobs:
         uses: test-summary/action@v1
         if: success() || failure()
         with:
-          paths: tests/pytest.xml
+          paths: ./.pytest_results.xml
 
       - name: 📊 Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         if: ${{ "{{" }} env.ENABLE_COVERAGE == 'true' }}
         with:
           fail_ci_if_error: true
-          files: ./.coverage.xml
+          files: ./.pytest_coverage.xml
 
 concurrency:
   group: workflow-ci-${{ "{{" }} github.ref }}-1

--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -1,9 +1,9 @@
 *.egg-info/
 *.pyc
 .coverage
-.coverage.xml
 .pytest_cache/
+.pytest_coverage.xml
+.pytest_results.xml
 .tox/
 .venv/
 dist/
-tests/pytest.xml

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -140,8 +140,8 @@ addopts = """\
     --cov \
     --cov-append \
     --cov-report term \
-    --cov-report xml:.coverage.xml \
-    --junitxml=tests/pytest.xml \
+    --cov-report xml:.pytest_coverage.xml \
+    --junitxml=.pytest_results.xml \
 """
 
 [tool.tox]


### PR DESCRIPTION
pytest was considering .coverage.xml as an input config file which
resulted in a console warning