### PR TITLE
Update project template cruft

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": ".",
-  "commit": "757202d63c5e720d55fbd434d89ab8f45cd0c6bb",
+  "commit": "c4899ec894c43ac32a763a480b6fb0f209503ede",
   "context": {
     "cookiecutter": {
       "project_name": "Cookiecutter template for new Python projects",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,14 @@ repos:
       - flake8-pyproject
       - flake8-simplify
       - pep8-naming
+  - repo: https://github.com/pycqa/autoflake
+    rev: v2.0.1
+    hooks:
+    - id: autoflake
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+    - id: pyupgrade
   - repo: local
     hooks:
     - id: mypy

--- a/cookie_python/manage/main.py
+++ b/cookie_python/manage/main.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 from enum import Enum
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable
 
 from loguru import logger
 
@@ -28,7 +28,7 @@ class Action(str, Enum):
     def __new__(
         cls,
         value: str,
-        func: Optional[Callable[[argparse.Namespace], None]] = None,
+        func: Callable[[argparse.Namespace], None] | None = None,
         description: str = "",
     ) -> Action:
         obj = str.__new__(cls, value)

--- a/cookie_python/manage/repo.py
+++ b/cookie_python/manage/repo.py
@@ -9,7 +9,7 @@ import tempfile
 from functools import cached_property
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Optional
+from typing import Any
 
 import loguru
 
@@ -30,9 +30,9 @@ class RepoSandbox:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]] = None,
-        exc_val: Optional[BaseException] = None,
-        exc_tb: Optional[TracebackType] = None,
+        exc_type: type[BaseException] | None = None,
+        exc_val: BaseException | None = None,
+        exc_tb: TracebackType | None = None,
     ) -> None:
         self._stack.close()
 
@@ -58,7 +58,7 @@ class RepoSandbox:
         )
 
     @cached_property
-    def logger(self) -> "loguru.Logger":
+    def logger(self) -> loguru.Logger:
         return loguru.logger.bind(repo=self.repo.full_name)
 
     @cached_property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ help = "Check all files"
 [tool.poe.tasks.pytest]
 cmd = "pytest"
 help = "Run unit tests with pytest"
+env = { PYTHON_KEYRING_BACKEND = "keyring.backends.null.Keyring" }
 
 [tool.poe.tasks.test]
 sequence = ["lint", "pytest"]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -68,11 +68,11 @@ def test_project_license(cookies: Any, project_license: str) -> None:
     if project_license in ("MIT", "BSD-3-Clause"):
         # Compare copyright line separately
         if project_license == "MIT":
-            expected_copyright = "Copyright (c) {0} Ness".format(
+            expected_copyright = "Copyright (c) {} Ness".format(
                 datetime.date.today().year
             )
         elif project_license == "BSD-3-Clause":
-            expected_copyright = "Copyright (c) {0}, Ness".format(
+            expected_copyright = "Copyright (c) {}, Ness".format(
                 datetime.date.today().year
             )
         assert license_data.splitlines()[0] == expected_copyright
@@ -171,11 +171,11 @@ def test_rendered_readme(
         ),
     )
 
-    with open(os.path.join(result.project_path, "README.md"), "r") as f:
+    with open(os.path.join(result.project_path, "README.md")) as f:
         readme = f.read()
     if opt_update_expected_outputs:
         with open(expected_content_file, "w") as f:
             f.write(readme)
 
-    with open(expected_content_file, "r") as f:
+    with open(expected_content_file) as f:
         assert readme == f.read()


### PR DESCRIPTION
Applied updates from upstream project template commits:

757202d63c5e720d55fbd434d89ab8f45cd0c6bb...c4899ec894c43ac32a763a480b6fb0f209503ede

```
*   c4899ec Merge pull request #90 from smkent/cruft-json-reset
|\  
| * f61ed02 Replace repo_reset with .cruft.json checkout
|/  
*   f5e42d6 Merge pull request #88 from smkent/autoflake-pyupgrade
|\  
| *   0d9d2ea Merge branch 'main' into autoflake-pyupgrade
| |\  
| |/  
|/|   
* |   a4fec71 Merge pull request #89 from smkent/fix-pyproject-version
|\ \  
| * | 62b1b68 Configure pyproject.toml build-backend for poetry-dynamic-versioning
| * | 85d5f74 Enable poetry-dynamic-versioning in pyproject.toml
| * | 549fc6e Update python-poetry action from template
| * | 1001f3e Add __version__.py
| * | 42f765f Remove fixed version string from pyproject.toml
|/ /  
| * d5f398c Add autoflake to pre-commit config
| * dda7315 Add pyupgrade to pre-commit config
|/  
*   429b0c8 Merge pull request #87 from smkent/manage-cookie-branch-name
|\  
| * 21aceda Tweak manage-cookie branch name
|/  
*   a3f5e77 Merge pull request #86 from smkent/update-cookie
|\  
| * a7ec03b Update dependencies
|/  
*   432da6a Merge pull request #85 from smkent/reference-self-current-dir
|\  
| * 3368613 Reference own template via current directory instead of URL
|/  
*   8ea43c8 Merge pull request #84 from smkent/skip-empty-updates
|\  
| * 0199bed Rework repository reset as a decorator
| * ee6e1de Reset repository working directory if skipping cruft update
| * 41940ba Capture output in git status command
| * 508f99d Skip cruft updates without template modifications
|/  
*   1b2d5ae Merge pull request #83 from smkent/ci-cd-pypi
|\  
| * 3366570 Enable publishing to PyPI
| * 77d2309 Apply CI/CD workflow updates from template
|/  
*   2c96f9e Merge pull request #82 from smkent/readme-badges
|\  
| *   5820d18 Merge remote-tracking branch 'origin/main' into readme-badges
| |\  
| |/  
|/|   
* |   c49a336 Merge pull request #81 from smkent/manage-main-loop
|\ \  
| * | 653af5b Move repository iteration loop to manage-cookie main function
|/ /  
| * 0de67eb Add PyPI badges to README.md
| * 01a9943 Add codecov badge to README.md
|/  
*   de9e951 Merge pull request #80 from smkent/github-api
|\  
| * 3343a19 Remove now-unused subprocess.run mock
| * d4fe333 Use PyGithub to create and locate releases
| * 77109a6 Mock PyGithub in unit tests, rename API token env var
| * b523f8e Use PyGithub for pull request creation, deletion
| * 7ef5da8 Use PyGithub to resolve repository from CLI params
| * 101cf80 Add pygithub
|/  
*   faaf379 Merge pull request #78 from smkent/replace-pr
|\  
| * 39a7465 Log opened PR URL
| * e89cc06 Close existing PR on update
| * 0305500 Don't check for existing branch on remote at clone time
* |   c21e45e Merge pull request #79 from smkent/release-log-fixup
|\ \  
| |/  
|/|   
| * 163d273 Fix release log message wording
|/  
*   4fe836a Merge pull request #77 from smkent/status-output
|\  
| * 4f087ad Tweak log messages
| * 3945331 Fix update loop continuation
| * 685a6ae Print status output in manage-cookie commands using loguru
| * e9c0b0f Add loguru
|/  
*   daed151 Merge pull request #76 from smkent/manage-release
|\  
| * bb1f6f5 Fixup manage-release update description text
| * d68915b Add tests for manage-cookie release
| * c0f8984 Move manage_cookie_main invocation to a helper function
| * 02de8c7 Split poetry.lock creation in new_cookie fixture to new fixture
| * 8a56ffe Implement manage-cookie release action
| * d75175b Create release action stub
| * c99f99d Improve action argument usage text
| * 34d3cf0 Add semver
|/  
*   ee4514f Merge pull request #75 from smkent/manage-cookie
|\  
| * 093053a Move cruft_attr to be a method on RepoSandbox
| * c821e2b Skip interactive shell invocation if not connected to a tty
| * 56add15 Move interactive shell invocation to a RepoSandbox method
| * d419981 Test manage-cookie update with and without updates to apply
| * 54491c0 Remove unused bits of code
| * 66fce53 Patch os.environ using patch.dict instead of patch.object
| * 0660473 Configure git author environment values via a fixture
| * ea8c79f Use existing local or freshly cloned template repo for commit graph
| * bca9b27 Provide values for git author name and email in manage-cookie tests
| * c910694 Fetch full repository history in CI/CD action
| * 2e7e1aa Add unit test for manage-cookie update flow
| * dd140a6 Implement repository update action
| * 40355c9 Refactor RepoSandbox
| * 2a40703 Remove ManageCookie class, move update action entry point to new file
| * 6db05ed Simplify manage-cookie main file
| * 31b15d8 Move RepoSandbox to a new file
| * a05cf4d Move manage-cookie code to a new subdirectory
| * 47ad7e6 Add manage cookie command and repo sandbox class
| * aea89aa Rename main.py to new.py
|/  
* 2662650 Merge pull request #74 from smkent/self-management
* 24d2599 Enable coverage report upload
* 4833749 Configure coverage
* 751c221 Add .cruft.json with current settings
```
