### PR TITLE
Add --keep-runtime-typing to pyupgrade args

### DIFF
--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
     rev: v3.3.1
     hooks:
     - id: pyupgrade
+      args: ["--keep-runtime-typing"]
   - repo: local
     hooks:
     - id: mypy


### PR DESCRIPTION
pyupgrade rewrites types in files that import __annotations__ from future, but modules that inspect type hints (such as dataclasses-json) don't understand the updated type annotations in Python 3.8.