### PR TITLE
Improve GitHub API/repo interactions in manage-cookie

### DIFF
--- a/tests/test_manage_cookie.py
+++ b/tests/test_manage_cookie.py
@@ -71,6 +71,7 @@ def mock_pygithub(new_cookie: Path) -> Iterator[MagicMock]:
             name=PROJECT_NAME,
             full_name=f"{AUTHOR_NAME}/{PROJECT_NAME}",
             ssh_url=str(new_cookie),
+            html_url=str(new_cookie),
             get_pulls=MagicMock(
                 return_value=[
                     SimpleNamespace(

--- a/tests/test_manage_cookie.py
+++ b/tests/test_manage_cookie.py
@@ -79,6 +79,7 @@ def mock_pygithub(new_cookie: Path) -> Iterator[MagicMock]:
                     )
                 ],
             ),
+            get_branch=lambda name: SimpleNamespace(name=name),
             get_latest_release=lambda: SimpleNamespace(title="v1.1.38"),
         )
         yield obj


### PR DESCRIPTION
- Use repo HTTP URL for repo clone
- Only attempt to delete existing manage-cookie branch if it exists